### PR TITLE
[TASK] Clean up usages of typo3conf/ext/styleguide

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -11,11 +11,6 @@
 // Configure admin panel
 config.admPanel = 1
 
-page.headerData.1568907945 = TEXT
-page.headerData.1568907945.value (
-  <link rel="shortcut icon" href="typo3conf/ext/styleguide/Resources/Public/Icons/Extension.svg" />
-)
-
 // Define template paths for fluid_styled_content
 lib.contentElement {
   templateName = Default
@@ -61,6 +56,7 @@ lib.dynamicContent {
 page = PAGE
 page {
   typeNum = 0
+  shortcutIcon = EXT:styleguide/Resources/Public/Icons/Extension.svg
   10 = FLUIDTEMPLATE
   10 {
     templateName = StyleguideFrontend


### PR DESCRIPTION
Some left over usages pointing to
typo3conf/ext/styleguide directly.

This is a backport for v12 compose-mode compatibility where files need to be referenced via API for path resolution to work (to use /_assets/… instead of a static path pointing to /typo3conf/).

Resolves: #102235
Releases: main, 12, 11
Upstream: https://review.typo3.org/c/Packages/TYPO3.CMS/+/81649